### PR TITLE
Fix issue with numeric printing incorrect JSON

### DIFF
--- a/db2util.c
+++ b/db2util.c
@@ -231,6 +231,10 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
     for (int i = 0; i < column_count; ++i) {
       col_info_t* col = cols + i;
 
+      if (col->ind == SQL_NTS) {
+        col->ind = strlen(col->data);
+      }
+
       switch(col->type) {
       case SQL_DECIMAL:
       case SQL_NUMERIC:

--- a/format_csv.c
+++ b/format_csv.c
@@ -18,11 +18,11 @@ static void csv_row(FILE* f, void* state, col_info_t* cols, int count) {
         const char* buffer = col->data;
         int length = col->ind;
 
-        if(length == SQL_NULL_DATA || length == SQL_DATA_AT_EXEC) {
+        if(length == SQL_NULL_DATA) {
             buffer = "null";
             length = 4;
         } 
-        else if (length == SQL_NTS) {
+        else if (length == SQL_NTS || length == SQL_DATA_AT_EXEC) {
             length = strlen(buffer);
         }
         

--- a/format_csv.c
+++ b/format_csv.c
@@ -18,7 +18,7 @@ static void csv_row(FILE* f, void* state, col_info_t* cols, int count) {
         const char* buffer = col->data;
         int length = col->ind;
 
-        if(length == SQL_NULL_DATA) {
+        if(length == SQL_NULL_DATA || length == SQL_DATA_AT_EXEC) {
             buffer = "null";
             length = 4;
         } 

--- a/format_csv.c
+++ b/format_csv.c
@@ -22,7 +22,7 @@ static void csv_row(FILE* f, void* state, col_info_t* cols, int count) {
             buffer = "null";
             length = 4;
         } 
-        else if (length == SQL_NTS || length == SQL_DATA_AT_EXEC) {
+        else if (length == SQL_NTS) {
             length = strlen(buffer);
         }
         

--- a/format_csv.c
+++ b/format_csv.c
@@ -21,9 +21,6 @@ static void csv_row(FILE* f, void* state, col_info_t* cols, int count) {
         if(length == SQL_NULL_DATA) {
             buffer = "null";
             length = 4;
-        } 
-        else if (length == SQL_NTS) {
-            length = strlen(buffer);
         }
         
         printf("%s\"", separator);

--- a/format_json.c
+++ b/format_json.c
@@ -69,14 +69,14 @@ static void json_row(FILE* f, void* state, col_info_t* cols, int count) {
         const char* buffer = col->data;
         int length = col->ind;
 
-        if(length == SQL_NULL_DATA) {
+        if(length == SQL_NULL_DATA || length == SQL_DATA_AT_EXEC) {
             buffer = "null";
             length = 4;
         } 
         else if (length == SQL_NTS) {
             length = strlen(buffer);
         }
-        
+
         printf("%s\"%s\":%s", comma, col->name, quote);
         
         for (int y = 0; y < length; y++) {

--- a/format_json.c
+++ b/format_json.c
@@ -73,7 +73,7 @@ static void json_row(FILE* f, void* state, col_info_t* cols, int count) {
             buffer = "null";
             length = 4;
         }
-        else if (length == SQL_NTS || length == SQL_DATA_AT_EXEC) {
+        else if (length == SQL_NTS) {
             length = strlen(buffer);
         }
 

--- a/format_json.c
+++ b/format_json.c
@@ -73,9 +73,6 @@ static void json_row(FILE* f, void* state, col_info_t* cols, int count) {
             buffer = "null";
             length = 4;
         }
-        else if (length == SQL_NTS) {
-            length = strlen(buffer);
-        }
 
         printf("%s\"%s\":%s", comma, col->name, quote);
         

--- a/format_json.c
+++ b/format_json.c
@@ -69,11 +69,11 @@ static void json_row(FILE* f, void* state, col_info_t* cols, int count) {
         const char* buffer = col->data;
         int length = col->ind;
 
-        if(length == SQL_NULL_DATA || length == SQL_DATA_AT_EXEC) {
+        if(length == SQL_NULL_DATA) {
             buffer = "null";
             length = 4;
-        } 
-        else if (length == SQL_NTS) {
+        }
+        else if (length == SQL_NTS || length == SQL_DATA_AT_EXEC) {
             length = strlen(buffer);
         }
 


### PR DESCRIPTION
This solves #11 for both JSON and CSV. When a value was returning `SQL_DATA_AT_EXEC`, it was not printing anything. Now instead, it prints `null` which is accepted by JSON and CSV parsers.