### PR TITLE
Save bound pointer for columns

### DIFF
--- a/db2util.c
+++ b/db2util.c
@@ -181,7 +181,7 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
     default:
       col->bind_type = SQL_C_CHAR;
       col->buffer_length = bind_length = size * 3;
-      col->buffer = col->data = malloc(col->buffer_length);
+      col->buffer = col->data = col->bind_ptr = malloc(col->buffer_length);
       break;
 
     case SQL_BINARY:
@@ -189,7 +189,7 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
     case SQL_BLOB:
       col->bind_type = SQL_C_CHAR;
       col->buffer_length = bind_length = size * 3;
-      col->buffer = col->data = malloc(col->buffer_length);
+      col->buffer = col->data = col->bind_ptr = malloc(col->buffer_length);
       break;
 
     case SQL_DECFLOAT:
@@ -201,7 +201,7 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
       col->bind_type = SQL_C_CHAR;
       col->buffer_length = 100;
       col->buffer = malloc(col->buffer_length);
-      col->data = col->buffer + 1;
+      col->data = col->bind_ptr = col->buffer + 1;
       bind_length = col->buffer_length - 1;
       break;
 
@@ -214,11 +214,11 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
     case SQL_INTEGER:
       col->bind_type = SQL_C_CHAR;
       col->buffer_length = bind_length = 100;
-      col->buffer = col->data = malloc(col->buffer_length);
+      col->buffer = col->data = col->bind_ptr = malloc(col->buffer_length);
       break;
     }
 
-    rc = SQLBindCol(hstmt, i+1, col->bind_type, col->data, bind_length, &col->ind);
+    rc = SQLBindCol(hstmt, i+1, col->bind_type, col->bind_ptr, bind_length, &col->ind);
     check_error(hstmt, SQL_HANDLE_STMT, rc);
   }
 
@@ -232,7 +232,7 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
       col_info_t* col = cols + i;
 
       if (col->ind == SQL_NTS) {
-        col->ind = strlen(col->data);
+        col->ind = strlen(col->bind_ptr);
       }
 
       switch(col->type) {

--- a/db2util.h
+++ b/db2util.h
@@ -13,6 +13,7 @@ typedef struct {
   SQLSMALLINT bind_type;
   SQLINTEGER ind;
   char* buffer;
+  char* bind_ptr;
   char* data;
   size_t buffer_length;
   char name[129];


### PR DESCRIPTION
In #12, the strlen() call was moved from the row functions in to
db2util_query. Because numeric data types adjust col->data, this means
we are now running strlen() on a pointer which may have been adjusted
previously and before it is adjusted for the current data. This can
cause the length to be off when passed to the row function and a NUL
byte accidentally output.

Instead, we add a new field to the col_info_t struct to save off the
pointer passed to SQLBindCol. This ensures our strlen() uses the same
pointer that SQLFetch put data in to and our lengths are consistent no
matter what value col->data has.

Fixes #14