### PR TITLE
fix: Bind input parameter length properly

### DIFF
--- a/db2util.c
+++ b/db2util.c
@@ -126,19 +126,14 @@ static int db2util_query(char* stmt, int fmt, int argc, const char* argv[]) {
   
   SQLINTEGER input_indicator = SQL_NTS;
   for (int i = 0; i < param_count; i++) {
-    SQLSMALLINT type;
-    SQLINTEGER precision;
-    SQLSMALLINT scale;
-    
-    // IBM i CLI doesn't allow passing NULL for parameters we
-    // don't care about, so we just pass a field and ignore it.
-    SQLSMALLINT ignore __attribute__((unused));
+    const char* arg = argv[i];
+    size_t precision = strlen(arg);
 
-    rc = SQLDescribeParam(hstmt, i+1, &type, &precision, &scale, &ignore);
-    check_error(hstmt, SQL_HANDLE_STMT, rc);
-
-    rc = SQLBindParameter(hstmt, i+1, SQL_PARAM_INPUT, SQL_C_CHAR, type,
-                          precision, scale, (SQLCHAR*) argv[i], 0, &input_indicator);
+    // NOTE: We specify SQL_CHAR since that saves calling SQLDescribeParam to
+    //       get the actual type and SQLBindParameter doesn't use this value
+    //       unless we specify SQL_C_DEFAULT anyway.
+    rc = SQLBindParameter(hstmt, i+1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR,
+                          precision, 0, (SQLCHAR*) arg, 0, &input_indicator);
     check_error(hstmt, SQL_HANDLE_STMT, rc);
   }
 


### PR DESCRIPTION
By passing the precision of the described type instead of the precision
of the actual type we're passing, we can get discrepancies that lead to
unexpected results. In the case of an INTEGER parameter, it will have a
precision of 4 (bytes) but a character length of up to 10. Since we bind
as character, CLI will treat this length as the character string length
(even though it's _supposed_ to use the bind indicator for this value
instead, *sigh*). Since we always bind as character and let CLI do the
conversion, we can eliminate the SQLDescribeParam and just pass the
length of the command line argument as the precision. The SQL type and
scale are not actually used in this case so we can specify "dummy"
values for them.

Fixes #16